### PR TITLE
fix: Add required env var for docker-compose

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,5 @@
+IMAGE_REPO_USER=o11yday
+
 # HONEYCOMB_API_KEY=your-api-key
 
 # you could change this to your own bucket of images. We accept no responsibility for the outcome.


### PR DESCRIPTION
## Which problem is this PR solving?

- The `docker-compose.yaml` file references `IMAGE_REPO_USER` for each docker image, but that environment variable is not set by default.

## Short description of the changes

- Set `IMAGE_REPO_USER=o11yday` in `.env` file as it is required for docker-compose. An alternative approach would be to hardcode those to o11yday (or to another if this is the wrong one).

## How to verify that this has the expected result

On main, `./run` fails. With this env var set in `.env` it succeeds in building and running the images.

```sh
➜  academy-instrumentation-nodejs git:(main) ./run
+ docker compose up --build -d
WARN[0000] The "IMAGE_REPO_USER" variable is not set. Defaulting to a blank string. 
WARN[0000] The "IMAGE_REPO_USER" variable is not set. Defaulting to a blank string. 
WARN[0000] The "IMAGE_REPO_USER" variable is not set. Defaulting to a blank string. 
WARN[0000] The "IMAGE_REPO_USER" variable is not set. Defaulting to a blank string. 
[+] Building 0.0s (0/0)
invalid tag "/meminator-nodejs:latest": invalid reference format
```

vs

```sh
➜  academy-instrumentation-nodejs git:(main) ✗ ./run
+ docker compose up --build -d
[+] Building 23.1s (61/61) FINISHED

...

 ✔ Network academy-instrumentation-nodejs_default                   Created        0.0s 
 ✔ Container academy-instrumentation-nodejs-meminator-1             Started        0.4s 
 ✔ Container academy-instrumentation-nodejs-image-picker-1          Started        0.4s 
 ✔ Container academy-instrumentation-nodejs-backend-for-frontend-1  Started        0.4s 
 ✔ Container academy-instrumentation-nodejs-phrase-picker-1         Started        0.4s 
 ✔ Container academy-instrumentation-nodejs-web-1                   Started        0.4s 
```